### PR TITLE
Add Travis and AppVeyor CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: csharp
+solution: rav1e_gui.sln

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,6 @@
 language: csharp
 solution: rav1e_gui.sln
+
+os:
+- linux
+- osx

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# rav1e_gui
+# rav1e_gui [![Travis Build Status](https://travis-ci.org/moisesmcardona/rav1e_gui.svg?branch=master)](https://travis-ci.org/moisesmcardona/rav1e_gui) [![AppVeyor Build Status](https://ci.appveyor.com/project/moisesmcardona/rav1e_gui/branch/master?svg=true)](https://ci.appveyor.com/project/moisesmcardona/rav1e_gui)
 A GUI to convert video files to AV1 using rav1e
 
 ![Main Window Screenshot](https://moisescardona.me/files/2018-12-09/1.webp)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,9 @@
+image: Visual Studio 2017
+configuration: Release
+
+build_script:
+ - msbuild c:\projects\rav1e_gui\build\rav1e_gui.sln
+
+artifacts:
+ - path: \**\rav1e_gui*.exe
+ - path: \**\rav1e_gui*.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,5 +2,4 @@ image: Visual Studio 2017
 configuration: Release
 
 artifacts:
- - path: \**\rav1e_gui*.exe
- - path: \**\rav1e_gui*.zip
+ - path: rav1e_gui\bin\Release\rav1e_gui.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,6 @@
 image: Visual Studio 2017
 configuration: Release
 
-build_script:
- - msbuild c:\projects\rav1e_gui\build\rav1e_gui.sln
-
 artifacts:
  - path: \**\rav1e_gui*.exe
  - path: \**\rav1e_gui*.zip


### PR DESCRIPTION
This PR adds continuous integration with Travis and AppVeyor. Travis automatically builds the project file on Linux and macOS, while AppVeyor builds on Windows and published the resulting .exe file.

I also added Build Status badges to the Readme.

To enable them you have to activate them on the GitHub Marketplace: [Travis CI](https://github.com/marketplace/travis-ci) and [AppVeyor](https://github.com/marketplace/appveyor).